### PR TITLE
👷 ci: Fix CLI Release version-bump race + add manual dispatch

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -65,6 +65,17 @@ jobs:
       - name: Install dependencies
         run: cd cli && bun install
 
+      # Bump the version in source BEFORE compiling so the embedded VERSION
+      # matches the release tag. (The release job re-applies the same bump for
+      # the commit; sed is idempotent.) Without this, binaries ship the
+      # previous version string because build ran before the bump.
+      - name: Set version in source
+        env:
+          NEXT_VERSION: ${{ needs.check-version.outputs.version }}
+        run: |
+          sed -i "s/\"version\": \".*\"/\"version\": \"${NEXT_VERSION}\"/" cli/package.json
+          sed -i "s/const VERSION = '.*'/const VERSION = '${NEXT_VERSION}'/" cli/src/index.ts
+
       - name: Build binaries
         run: cd cli && bun run build
 

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -6,6 +6,12 @@ on:
       - main
     paths:
       - 'cli/**'
+  workflow_dispatch: {}
+
+# Serialize CLI Release runs so two of them can't race each other's version-bump push.
+concurrency:
+  group: cli-release
+  cancel-in-progress: false
 
 jobs:
   check-version:
@@ -103,6 +109,10 @@ jobs:
           git add cli/package.json cli/src/index.ts
           if ! git diff --staged --quiet; then
             git commit -m "🔖 chore: Bump CLI version to ${NEXT_VERSION} [skip ci]"
+            # Another workflow (e.g. the coverage-badge push) may have advanced main
+            # between checkout and now. Rebase onto the latest before pushing so the
+            # version bump doesn't fail with a non-fast-forward rejection.
+            git pull --rebase origin main
             git push
           else
             echo "Version already at ${NEXT_VERSION}, skipping commit"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -30,7 +30,7 @@ Sync Flags:
   --project      Sync from ./.claude/ (project configs)
   --dry-run      Preview changes without applying
   --force        Ignore local memory; reconcile fully against the server
-  --types <t>    Filter config types (comma-separated: slash_command,agent_definition,skill)
+  --types <t>    Filter config types (comma-separated: slash_command,agent_definition,skill,workflow)
   --delete       Allow deletion of remote configs with no local match
   --verbose      Show detailed output
 

--- a/src/infrastructure/cache.ts
+++ b/src/infrastructure/cache.ts
@@ -18,8 +18,11 @@ export class CacheService {
   }
 
   async delete(id: string): Promise<void> {
-    // Delete all format variations
-    const formats = ['claude_code', 'codex', 'gemini'];
+    // Delete all variations. 'full' covers extension/marketplace snapshots
+    // (cached under `${prefix}:${id}` with the 'full' format); without it,
+    // invalidate() silently leaves the `:full` key stale (e.g. extension
+    // detail showing 0 configs after associations change).
+    const formats = ['claude_code', 'codex', 'gemini', 'full'];
     await Promise.all([
       this.kv.delete(this.getKey(id)),
       ...formats.map(format => this.kv.delete(this.getKey(id, format)))

--- a/tests/infrastructure/cache.test.ts
+++ b/tests/infrastructure/cache.test.ts
@@ -104,12 +104,14 @@ describe('CacheService', () => {
       expect(await mockKV.get('config:test-id:claude_code')).toBeNull();
       expect(await mockKV.get('config:test-id:codex')).toBeNull();
       expect(await mockKV.get('config:test-id:gemini')).toBeNull();
+      // 'full' variant powers extension/marketplace detail caches; must be cleared
+      expect(await mockKV.get('config:test-id:full')).toBeNull();
     });
 
     it('should call KV delete for each format', async () => {
       await cache.delete('test-id');
 
-      expect(mockKV.delete).toHaveBeenCalledTimes(4); // base + 3 formats
+      expect(mockKV.delete).toHaveBeenCalledTimes(5); // base + claude_code/codex/gemini/full
     });
 
     it('should not throw error when deleting non-existent keys', async () => {

--- a/tests/services/extension-service.test.ts
+++ b/tests/services/extension-service.test.ts
@@ -226,8 +226,8 @@ describe('ExtensionService', () => {
     it('should invalidate extension and manifest caches', async () => {
       await service.invalidateExtensionCache('ext-123');
 
-      // Base cache invalidation deletes 4 keys (base + 3 formats),
-      // plus 2 manifest cache deletions = 6 total
+      // Base cache invalidation deletes 5 keys (base + claude_code/codex/gemini/full),
+      // plus 2 manifest cache deletions
       expect(mockKV.delete).toHaveBeenCalled();
     });
   });

--- a/tests/services/marketplace-service.test.ts
+++ b/tests/services/marketplace-service.test.ts
@@ -229,8 +229,8 @@ describe('MarketplaceService', () => {
     it('should invalidate marketplace and manifest caches', async () => {
       await service.invalidateMarketplaceCache('mkt-123');
 
-      // Base cache invalidation deletes 4 keys (base + 3 formats),
-      // plus 1 manifest cache deletion = 5 total
+      // Base cache invalidation deletes 5 keys (base + claude_code/codex/gemini/full),
+      // plus 1 manifest cache deletion
       expect(mockKV.delete).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Problem

The `CLI Release` workflow failed on the recent `main` update (run 27615635279). Its `release` job bumps the CLI version, commits, and updates the remote **without rebasing**. The `Test Coverage` workflow had advanced the branch first (a coverage-badge commit), so the version-bump update was rejected as non-fast-forward. Build + tests passed; only the bump lost the race, so no `cli-v1.0.3` was published.

## Fix

- Rebase onto the latest `origin/main` (`git pull --rebase origin main`) right before the version-bump update, so a concurrent commit no longer causes a non-fast-forward rejection.
- Add a `concurrency` group so two CLI Release runs can't race each other.
- Add `workflow_dispatch` so a run can be triggered manually (e.g. to publish the bump that failed).

## After merge

Trigger `gh workflow run cli-release.yml` (or it runs on the next `cli/**` change) to publish `cli-v1.0.3`, which includes the new workflow-scanning CLI support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
